### PR TITLE
Move stream_lag_labels from config

### DIFF
--- a/root-files/opt/flownative/promtail/etc/config.yaml
+++ b/root-files/opt/flownative/promtail/etc/config.yaml
@@ -27,7 +27,9 @@ clients:
       max_retries: 10
     timeout: 10s
     tenant_id: ${PROMTAIL_CLIENT_TENANT_ID}
-    stream_lag_labels: filename
     basic_auth:
       username: ${PROMTAIL_BASIC_AUTH_USERNAME}
       password: ${PROMTAIL_BASIC_AUTH_PASSWORD}
+
+options:
+  stream_lag_labels: filename


### PR DESCRIPTION
This currently throws the following error:
"client config stream_lag_labels is deprecated in favour of the config file options block field, and will be ignored"