### PR TITLE
Upgrade to Promtail 3.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/promtail:3.2.0 AS promtail
+FROM grafana/promtail:3.3.2 AS promtail
 FROM europe-docker.pkg.dev/flownative/docker/base:bookworm
 LABEL org.opencontainers.image.authors="Robert Lemke <robert@flownative.com>"
 
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.authors="Robert Lemke <robert@flownative.com>"
 # Promtail
 # Latest versions: https://github.com/grafana/loki/releases / https://hub.docker.com/r/grafana/promtail/tags
 
-ENV PROMTAIL_VERSION=3.2.0
+ENV PROMTAIL_VERSION=3.3.2
 
 ENV FLOWNATIVE_LIB_PATH=/opt/flownative/lib \
     PROMTAIL_BASE_PATH=/opt/flownative/promtail \


### PR DESCRIPTION
Contains no breaking changes which would affect our usage.