### PR TITLE
Provide "pod" label with log entries

### DIFF
--- a/root-files/opt/flownative/promtail/etc/config-template.yaml
+++ b/root-files/opt/flownative/promtail/etc/config-template.yaml
@@ -8,6 +8,7 @@ scrape_configs:
         labels:
           __dynamic_labels__
           host: ${PROMTAIL_LABEL_HOST}
+          pod: ${PROMTAIL_LABEL_POD_NAME}
           __path__: ${PROMTAIL_SCRAPE_PATH}
 
 server:


### PR DESCRIPTION
This adds a new label "pod" containing the current pod name to all log entries.